### PR TITLE
Add REJECT Pokémon UNITE division data (team, members, roster)

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -76,3 +76,21 @@ player:
     name: Cocoatta
     alias: [ここあった]
     reference: [https://x.com/cocoa_poke_]
+  yakou:
+    name: Yakou
+    reference: [https://prtimes.jp/main/html/rd/p/000000116.000050979.html]
+  piui:
+    name: piui
+    reference: [https://prtimes.jp/main/html/rd/p/000000116.000050979.html]
+  haruta:
+    name: Haruta
+    reference: [https://prtimes.jp/main/html/rd/p/000000116.000050979.html]
+  tamerin:
+    name: Tamerin
+    reference: [https://prtimes.jp/main/html/rd/p/000000116.000050979.html]
+  satake:
+    name: Satake
+    reference: [https://prtimes.jp/main/html/rd/p/000000116.000050979.html]
+  o2:
+    name: O2
+    reference: [https://prtimes.jp/main/html/rd/p/000000116.000050979.html]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -70,3 +70,16 @@ zeta-division:
     reference:
       - https://zetadivision.com/news/2025/05/21/34042
     date: 2025-05-21
+reject:
+  - member:
+      in:
+        - yakou
+        - piui
+        - haruta
+        - tamerin
+        - satake
+        - o2
+    reference:
+      - https://prtimes.jp/main/html/rd/p/000000116.000050979.html
+      - https://reject.jp/2024/05/27/%E3%80%90%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3%E3%83%A6%E3%83%8A%E3%82%A4%E3%83%88%E3%80%91%E3%80%8CREJECT-jsv%E3%80%8D%E3%81%A8%E3%81%97%E3%81%A6%E9%83%A8%E9%96%80%E8%A8%AD%E7%AB%8B%E5%8F%8A%E3%81%B3%E6%96%B0%E7%99%BA%E8%A1%A8/
+    date: 2024-05-28

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -14,3 +14,8 @@ zeta-division:
   name: ZETA DIVISION
   reference:
     - https://zetadivision.com/team/pokemon-unite
+reject:
+  name: REJECT
+  reference:
+    - https://reject.jp/2024/05/27/%E3%80%90%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3%E3%83%A6%E3%83%8A%E3%82%A4%E3%83%88%E3%80%91%E3%80%8CREJECT-jsv%E3%80%8D%E3%81%A8%E3%81%97%E3%81%A6%E9%83%A8%E9%96%80%E8%A8%AD%E7%AB%8B%E5%8F%8A%E3%81%B3%E6%96%B0%E7%99%BA%E8%A1%A8/
+    - https://prtimes.jp/main/html/rd/p/000000116.000050979.html


### PR DESCRIPTION
# Add REJECT Pokémon UNITE division data (team, members, roster)

## Summary
Added REJECT's Pokémon UNITE division to the database with their initial roster from May 2024. This includes:
- Team entry in `data/team.yaml` with official reference URLs
- 6 new players in `data/member.yaml`: yakou, piui, haruta, tamerin, satake, o2  
- Initial roster event in `data/roster.yaml` dated 2024-05-28 with all founding members

Data sourced from official REJECT announcements and PR TIMES press release.

## Review & Testing Checklist for Human
- [ ] **Verify reference URLs are accessible** - check that both reject.jp and prtimes.jp links work properly
- [ ] **Confirm player names/spellings are accurate** - cross-reference with official sources or player social media
- [ ] **Check for missing recent roster changes** - verify this is the current/complete roster or if there have been updates since May 2024
- [ ] **Test site functionality** - run `npm run dev` and verify REJECT appears in team list and team detail page displays correctly
- [ ] **Validate date accuracy** - confirm 2024-05-28 is the correct establishment date (REJECT site says 2024-05-27, PR TIMES says 2024-05-28)

### Notes
- All player references currently point to the same PR TIMES article; individual social media links could be added later for better attribution
- Only included the initial team formation event - may need future updates for roster changes
- Schema validation and build tests passed locally

**Link to Devin run:** https://app.devin.ai/sessions/f06e1d0733ae4d579983411604ed39c6  
**Requested by:** Sh Su (@s2terminal)