### PR TITLE
Add AXIZ team roster and member data

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -104,3 +104,21 @@ player:
     name: Pavóne
     alias: [Pavone, Ireteya]
     reference: [https://x.com/Pavone0223125]
+  respectm:
+    name: Respect・M
+    reference: [https://x.com/SumiriA_]
+  yupono:
+    name: Yupono
+    reference: [https://x.com/soarin_yupono]
+  shiel:
+    name: shiel
+    reference: [https://x.com/hx1e_]
+  polin:
+    name: Polin
+    reference: [https://x.com/tmel_dlr]
+  bagel:
+    name: bagel
+    reference: [https://x.com/bagel_beguru]
+  laby:
+    name: Laby
+    reference: [https://x.com/xcicada3301x]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -1,4 +1,40 @@
 # yaml-language-server: $schema=./schema/roster.schema.json
+axiz:
+  - member:
+      in:
+        - yupono
+        - shiel
+        - polin
+        - bagel
+        - laby
+        - omutero
+    reference:
+      - https://axiz.gg/topics/public/jq8f9jh3nxe4083a.html
+    date: 2024-10-08
+  - member:
+      out:
+        - bagel
+        - laby
+        - omutero
+    reference:
+      - https://x.com/AXIZ_gg/status/1906632561419309072
+    date: 2025-03-31
+  - member:
+      in:
+        - mame
+        - kabikiller
+        - respectm
+    reference:
+      - https://axiz.gg/topics/public/gjpyybngbbemc501.html
+    date: 2025-04-15
+  - member:
+      out:
+        - mame
+        - polin
+        - respectm
+    reference:
+      - https://x.com/AXIZ_gg/status/1951206266812162161
+    date: 2025-08-01
 insomnia:
   - member:
       in:

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=./schema/team.schema.json
+axiz:
+  name: AXIZ
+  alias:
+    - アクシズ
+  reference:
+    - https://axiz.gg/team/Pok%C3%A9mon%20UNITE/
 insomnia:
   name: INSOMNIA
   reference:


### PR DESCRIPTION
## Summary
- add AXIZ team entry with official site
- record AXIZ roster history and players
- register new AXIZ players with social links
- separate departure of bagel, laby, and omutero with March 31 tweet

## Testing
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68adbb49ca308320bdc8c8e8416a7cda