### PR TITLE
Add BURNING CORE TOYAMA team

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -104,3 +104,26 @@ player:
     name: Pavóne
     alias: [Pavone, Ireteya]
     reference: [https://x.com/Pavone0223125]
+  harusame:
+    name: はるさめ
+    reference: [https://x.com/somarion787]
+  euclid:
+    name: ユークリッド
+    reference: [https://x.com/Euclid_666_]
+  "1st_ruru":
+    name: 1st_ruru
+    reference: [https://x.com/0926mirror]
+  zeras:
+    name: ゼラス
+    reference: [https://x.com/zerasususu]
+  kageatai:
+    name: かげ値
+    alias: [まりかげ値]
+    reference: [https://x.com/kageatai_dayo]
+  takubin:
+    name: たくびん
+    reference: [https://x.com/takubin_pu]
+  nyaga:
+    name: おにゃが
+    alias: [Nyaga]
+    reference: [https://x.com/Nyaga_gyakubari]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -1,4 +1,22 @@
 # yaml-language-server: $schema=./schema/roster.schema.json
+burning-core-toyama:
+  - member:
+      in:
+        - harusame
+        - euclid
+        - "1st_ruru"
+        - zeras
+        - kageatai
+        - takubin
+    reference: [https://burning-core.com/news/2060]
+    date: 2025-01-21
+  - member:
+      out:
+        - kageatai
+      in:
+        - nyaga
+    reference: [https://x.com/burning_core/status/1912083488377127046]
+    date: 2025-04-15
 insomnia:
   - member:
       in:

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=./schema/team.schema.json
+burning-core-toyama:
+  name: BURNING CORE TOYAMA
+  alias:
+    - BC Toyama
+    - BURNING CORE 富山
+  reference:
+    - https://burning-core.com/
 insomnia:
   name: INSOMNIA
   reference:


### PR DESCRIPTION
## Summary
- add BURNING CORE TOYAMA to team registry with aliases
- register BURNING CORE TOYAMA roster and players
- track Kageatai leaving and Nyaga joining the roster

## Testing
- `npm run validate`
- `curl -I https://burning-core.com/`
- `curl -I https://burning-core.com/news/2060`
- `curl -I https://x.com/burning_core/status/1912083488377127046`
- `curl -I https://x.com/Nyaga_gyakubari`


------
https://chatgpt.com/codex/tasks/task_e_68adcfaac5b88320ae25889889064735