### PR TITLE
Add ENTER FORCE.36 roster and team data

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -104,3 +104,23 @@ player:
     name: Pavóne
     alias: [Pavone, Ireteya]
     reference: [https://x.com/Pavone0223125]
+  kota:
+    name: Kota
+    alias: [コータ]
+    reference: [https://x.com/RK_01130417]
+  nomu:
+    name: Nomu
+    alias: [ノム]
+    reference: [https://x.com/_xial2_]
+  iskw:
+    name: ISKW
+    alias: [イシカワ]
+    reference: [https://x.com/Zuk1280]
+  seno:
+    name: Seno
+    alias: [セノ]
+    reference: [https://x.com/senochiiii]
+  cham:
+    name: cham
+    alias: [チャム]
+    reference: [https://x.com/cham09126]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=./schema/roster.schema.json
+enterforce36:
+  - member:
+      in:
+        - kota
+        - nomu
+        - iskw
+        - seno
+        - cham
+    reference:
+      - https://enterforce-36.com/2025/06/14/pokemon-unite-div/
+    date: 2025-06-14
 insomnia:
   - member:
       in:

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=./schema/team.schema.json
+enterforce36:
+  name: ENTER FORCE.36
+  alias:
+    - ENTER FORCE 36
+    - E36
+  reference:
+    - https://enterforce-36.com/
 insomnia:
   name: INSOMNIA
   reference:


### PR DESCRIPTION
## Summary
- add ENTER FORCE.36 team info
- record initial roster from Pokémon UNITE division announcement
- register profiles for Kota, Nomu, ISKW, Seno, and cham

## Testing
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68b05882fe08832095d25c4ce4f1a37d