### PR TITLE
Add SCARZ team and roster

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -104,3 +104,21 @@ player:
     name: Pavóne
     alias: [Pavone, Ireteya]
     reference: [https://x.com/Pavone0223125]
+  cotora:
+    name: cotoRa
+    reference: [https://x.com/nitorasu1258]
+  kamenero:
+    name: Kamenero
+    reference: [https://x.com/kamenero012]
+  kusamusi:
+    name: Kusamusi
+    reference: [https://x.com/musityanndesu]
+  shiganaki:
+    name: Shiganaki
+    reference: [https://x.com/yu1re_re]
+  okamoto:
+    name: Okamoto
+    reference: [https://x.com/KAZUYASEVENN]
+  dorap1n:
+    name: Dorap1n
+    reference: [https://x.com/dorap1n]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -72,6 +72,18 @@ reject:
       - https://x.com/RC_REJECT/status/1906632576460321128
     date: 2025-03-31
     memo: O2はREJECTのboard memberとして活動を継続
+scarz:
+  - member:
+      in:
+        - cotora
+        - kamenero
+        - kusamusi
+        - shiganaki
+        - okamoto
+        - dorap1n
+    reference:
+      - https://www.scarz.net/news/25061902/
+    date: 2025-06-19
 zeta-division:
   - member:
       in:

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -16,6 +16,10 @@ reject:
     - REJECT JSV
   reference:
     - https://reject.jp/team/pokemon-unite
+scarz:
+  name: SCARZ
+  reference:
+    - https://www.scarz.net/team/pokemon-unite/
 zeta-division:
   name: ZETA DIVISION
   reference:


### PR DESCRIPTION
## Summary
- add SCARZ team entry with official site reference
- record initial SCARZ roster and player profiles
- link roster to SCARZ's Pokémon UNITE announcement article

## Testing
- `curl -I https://www.scarz.net/news/25061902/`
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68af203abbb483209750842348322ccd