### PR TITLE
fix: make internal links and favicon respect BASE_URL for GitHub Pages

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,7 @@ export default function Header() {
           Unite Pro Teams JP
         </Typography>
         <Box sx={{ display: 'flex', gap: 2 }}>
-          <Link href="/" color="inherit" underline="hover">チーム一覧</Link>
+          <Link href={`${import.meta.env.BASE_URL}`} color="inherit" underline="hover">チーム一覧</Link>
         </Box>
       </Toolbar>
     </AppBar>

--- a/src/components/PlayerDetail.tsx
+++ b/src/components/PlayerDetail.tsx
@@ -36,7 +36,7 @@ export default function PlayerDetail({ player, currentTeam, history, teamBySlug 
         <CardContent>
           <Typography variant="h6" gutterBottom>現在の所属</Typography>
           {currentTeam ? (
-            <Typography><Link href={`/team/${currentTeam}/`}>{teamBySlug[currentTeam]?.name ?? currentTeam}</Link></Typography>
+            <Typography><Link href={`${import.meta.env.BASE_URL}team/${currentTeam}/`}>{teamBySlug[currentTeam]?.name ?? currentTeam}</Link></Typography>
           ) : (
             <Typography color="text.secondary">所属なし</Typography>
           )}
@@ -50,7 +50,7 @@ export default function PlayerDetail({ player, currentTeam, history, teamBySlug 
             <Box sx={{ display: 'grid', gap: 1 }}>
               {history.map((h, idx) => (
                 <Typography key={idx}>
-                  <strong>{h.date}</strong> {h.action === 'in' ? '加入' : '離脱'} - <Link href={`/team/${h.team}/`}>{teamBySlug[h.team]?.name ?? h.team}</Link>
+                  <strong>{h.date}</strong> {h.action === 'in' ? '加入' : '離脱'} - <Link href={`${import.meta.env.BASE_URL}team/${h.team}/`}>{teamBySlug[h.team]?.name ?? h.team}</Link>
                 </Typography>
               ))}
             </Box>

--- a/src/components/TeamDetail.tsx
+++ b/src/components/TeamDetail.tsx
@@ -41,7 +41,7 @@ export default function TeamDetail({ team, current, history, playersBySlug }: {
           {current.length ? (
             <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
               {current.map((pslug) => (
-                <Chip key={pslug} clickable component="a" href={`/player/${pslug}/`} label={playersBySlug[pslug]?.name ?? pslug} />
+                <Chip key={pslug} clickable component="a" href={`${import.meta.env.BASE_URL}player/${pslug}/`} label={playersBySlug[pslug]?.name ?? pslug} />
               ))}
             </Stack>
           ) : (
@@ -63,7 +63,7 @@ export default function TeamDetail({ team, current, history, playersBySlug }: {
                       加入:{' '}
                       {h.member.in.map((s, i) => (
                         <>
-                          <Link key={`in-${s}`} href={`/player/${s}/`}>
+                          <Link key={`in-${s}`} href={`${import.meta.env.BASE_URL}player/${s}/`}>
                             {playersBySlug[s]?.name ?? s}
                           </Link>
                           {i < (h.member.in?.length ?? 0) - 1 ? ', ' : ''}
@@ -76,7 +76,7 @@ export default function TeamDetail({ team, current, history, playersBySlug }: {
                       {' '}離脱:{' '}
                       {h.member.out.map((s, i) => (
                         <>
-                          <Link key={`out-${s}`} href={`/player/${s}/`}>
+                          <Link key={`out-${s}`} href={`${import.meta.env.BASE_URL}player/${s}/`}>
                             {playersBySlug[s]?.name ?? s}
                           </Link>
                           {i < (h.member.out?.length ?? 0) - 1 ? ', ' : ''}

--- a/src/components/TeamList.tsx
+++ b/src/components/TeamList.tsx
@@ -22,7 +22,7 @@ export default function TeamList({ teams }: { teams: Team[] }) {
     >
       {teams.map((t) => (
         <Card key={t.slug} variant="outlined">
-          <CardActionArea href={`/team/${t.slug}/`}>
+          <CardActionArea href={`${import.meta.env.BASE_URL}team/${t.slug}/`}>
             <CardContent>
               <Typography variant="h6" component="div">{t.name}</Typography>
               {t.memo && (

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,7 +8,7 @@ import Header from '../components/Header';
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
     <meta name="generator" content={Astro.generator} />
     <title>Astro Basics</title>
   </head>


### PR DESCRIPTION
# fix: make internal links and favicon respect BASE_URL for GitHub Pages

## Summary
Fixes 404 errors on non-root pages when deployed to GitHub Pages by updating all internal links and the favicon to use `import.meta.env.BASE_URL` instead of absolute root paths. 

When deployed to GitHub Pages as a project site, the app lives under `/unite-pro-team-jp/` but the hardcoded `/` links were pointing to the domain root, causing 404s. This PR updates:

- Header home link: `"/"` → `${import.meta.env.BASE_URL}`  
- Team list cards: `"/team/${slug}/"` → `${import.meta.env.BASE_URL}team/${slug}/`
- Team detail player chips and history links: `"/player/${slug}/"` → `${import.meta.env.BASE_URL}player/${slug}/`
- Player detail team links: `"/team/${slug}/"` → `${import.meta.env.BASE_URL}team/${slug}/`
- Favicon: `"/favicon.svg"` → `${import.meta.env.BASE_URL}favicon.svg`

The existing `astro.config.mjs` correctly sets the base path from `GITHUB_REPOSITORY` in CI, so no config changes were needed.

## Review & Testing Checklist for Human (4 items)

- [ ] **Critical: Verify navigation works end-to-end on the actual GitHub Pages deployment** - click through from index → team pages → player pages → back to teams and ensure no 404s occur
- [ ] **Verify favicon loads correctly** on the deployed GitHub Pages site (check browser dev tools if needed)
- [ ] **Spot check that external reference links still work** - ensure any external URLs in team/player data weren't accidentally modified to use BASE_URL
- [ ] **Test the header "チーム一覧" link** returns to the home page correctly from any sub-page

### Notes
- Built and tested locally with GitHub Pages environment variables - build succeeds but actual GitHub Pages deployment testing is needed
- All changes use the standard Astro pattern `import.meta.env.BASE_URL` for base-aware URLs
- External reference links in the data remain unchanged (they should not use BASE_URL)

**Link to Devin run:** https://app.devin.ai/sessions/a53fff3a275840acb5e05d515ee72a8f  
**Requested by:** @s2terminal