### PR TITLE
Add Yoshimoto Gaming medetashi founding roster

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -10,6 +10,10 @@ player:
   tsuntsun:
     name: TsunTsun
     reference: [https://x.com/tun4dd]
+  tsutsumi:
+    name: ツツミ
+    alias: [Tsutsumi]
+    reference: [https://x.com/unite_kakkin]
   usakazu:
     name: USAKAZU
     reference: [https://x.com/usakazuda]
@@ -25,6 +29,26 @@ player:
   vin:
     name: びいん
     reference: [https://x.com/shir_sw]
+  arcana:
+    name: あるかな
+    alias: [arcana]
+    reference: [https://x.com/uiosdh]
+  awainu:
+    name: あわいぬ
+    alias: [Awainu]
+    reference: [https://x.com/AwaichanX]
+  azubelto:
+    name: あずべると
+    alias: [Azubelto]
+    reference: [https://x.com/_azu_desu_]
+  lamiry:
+    name: らみりー
+    alias: [Lamiliy]
+    reference: [https://x.com/Lamiliy_D4]
+  yokuga:
+    name: ヨクガ
+    alias: [Yokuga]
+    reference: [https://x.com/yokuga89]
   kabikiller:
     name: kabikiller
     reference: [https://x.com/kabi_nnn]
@@ -79,6 +103,10 @@ player:
   yakou:
     name: Yakou
     reference: [https://x.com/yakoulamperouge]
+  yamada:
+    name: 山田
+    alias: [Yamada]
+    reference: [https://x.com/yamadaaaaaaaavv]
   piui:
     name: piui
     reference: [https://x.com/piui037]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -149,6 +149,38 @@ scarz:
     reference:
       - https://www.scarz.net/news/25061902/
     date: 2025-06-19
+yoshimoto-gaming-medetashi:
+  - member:
+      in:
+        - azubelto
+        - tsutsumi
+        - hayatobi
+        - yamada
+        - lamiry
+        - awainu
+    reference:
+      - https://yoshimoto-gaming.com/news/2876/
+    date: 2024-09-08
+  - member:
+      in:
+        - yokuga
+    reference:
+      - https://nitter.net/GamingYOSHIMOTO/status/1877633983409750101
+    date: 2025-01-10
+  - member:
+      in:
+        - chanme
+        - arcana
+        - vin
+    reference:
+      - https://nitter.net/GamingYOSHIMOTO/status/1912068388693717381
+    date: 2025-04-15
+  - member:
+      out:
+        - arcana
+    reference:
+      - https://nitter.net/GamingYOSHIMOTO/status/1953750533249945898
+    date: 2025-08-08
 zeta-division:
   - member:
       in:

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -168,15 +168,19 @@ yoshimoto-gaming:
       - https://x.com/GamingYOSHIMOTO/status/1877633983409750101
     date: 2025-01-10
   - member:
-      in:
-        - chanme
-        - arcana
-        - vin
       out:
         - tsutsumi
         - hayatobi
         - yamada
         - awainu
+    reference:
+      - https://x.com/GamingYOSHIMOTO/status/1906632573062979981
+    date: 2025-03-31
+  - member:
+      in:
+        - chanme
+        - arcana
+        - vin
     reference:
       - https://x.com/GamingYOSHIMOTO/status/1912068388693717381
     date: 2025-04-15

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -149,7 +149,7 @@ scarz:
     reference:
       - https://www.scarz.net/news/25061902/
     date: 2025-06-19
-yoshimoto-gaming-medetashi:
+yoshimoto-gaming:
   - member:
       in:
         - azubelto
@@ -165,21 +165,26 @@ yoshimoto-gaming-medetashi:
       in:
         - yokuga
     reference:
-      - https://nitter.net/GamingYOSHIMOTO/status/1877633983409750101
+      - https://x.com/GamingYOSHIMOTO/status/1877633983409750101
     date: 2025-01-10
   - member:
       in:
         - chanme
         - arcana
         - vin
+      out:
+        - tsutsumi
+        - hayatobi
+        - yamada
+        - awainu
     reference:
-      - https://nitter.net/GamingYOSHIMOTO/status/1912068388693717381
+      - https://x.com/GamingYOSHIMOTO/status/1912068388693717381
     date: 2025-04-15
   - member:
       out:
         - arcana
     reference:
-      - https://nitter.net/GamingYOSHIMOTO/status/1953750533249945898
+      - https://x.com/GamingYOSHIMOTO/status/1953750533249945898
     date: 2025-08-08
 zeta-division:
   - member:

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -44,9 +44,7 @@ zeta-division:
   name: ZETA DIVISION
   reference:
     - https://zetadivision.com/team/pokemon-unite
-yoshimoto-gaming-medetashi:
-  name: YOSHIMOTO Gaming medetashi
-  alias:
-    - よしもとゲーミングめでたし
+yoshimoto-gaming:
+  name: よしもとゲーミングめでたし
   reference:
-    - https://yoshimoto-gaming.com/
+    - https://yoshimoto-gaming.com/progamer/%e3%82%81%e3%81%a7%e3%81%9f%e3%81%97/

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -44,3 +44,9 @@ zeta-division:
   name: ZETA DIVISION
   reference:
     - https://zetadivision.com/team/pokemon-unite
+yoshimoto-gaming-medetashi:
+  name: YOSHIMOTO Gaming medetashi
+  alias:
+    - よしもとゲーミングめでたし
+  reference:
+    - https://yoshimoto-gaming.com/


### PR DESCRIPTION
## Summary
- record initial Yoshimoto Gaming medetashi lineup from 2024-09-08 announcement
- add Tsutsumi, Awainu, and Yamada to the member directory with X references

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68b3117ca07883208a870c80bf590d6d