### PR TITLE
Add Nagoya OJA team roster

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -186,3 +186,25 @@ player:
   katastol:
     name: Katastol
     reference: [https://x.com/katastol_]
+  hotarunoken:
+    name: Hotaru-no-Ken
+    alias: [ホタルノケン]
+    reference: [https://x.com/nonpunch1]
+  aporo:
+    name: Aporo
+    alias: [あぽろ]
+    reference: [https://x.com/NOJ_Aporo]
+  holly:
+    name: Holly
+    reference: [https://x.com/NOJ_Holly]
+  yama:
+    name: Yama
+    alias: [やま]
+    reference: [https://x.com/NOJ_Yama]
+  syu:
+    name: syu
+    reference: [https://x.com/NOJ_syu]
+  iroas:
+    name: Iroas
+    alias: [イロアス]
+    reference: [https://x.com/NOJ_Iroas]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -175,3 +175,15 @@ zeta-division:
     reference:
       - https://zetadivision.com/news/2025/05/21/34042
     date: 2025-05-21
+nagoya-oja:
+  - member:
+      in:
+        - hotarunoken
+        - aporo
+        - holly
+        - yama
+        - syu
+        - iroas
+    reference:
+      - https://prtimes.jp/main/html/rd/p/000000054.000060029.html
+    date: 2024-11-09

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -44,3 +44,9 @@ zeta-division:
   name: ZETA DIVISION
   reference:
     - https://zetadivision.com/team/pokemon-unite
+nagoya-oja:
+  name: NAGOYA OJA
+  alias:
+    - 名古屋OJA
+  reference:
+    - https://www.nagoyaoja.com/


### PR DESCRIPTION
## Summary
- add player entries for NAGOYA OJA
- record initial roster announcement with six members

## Testing
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68b3115200048320911338b4da0b59b7