### PR TITLE
elDiveGamingの2023年ロスター情報を更新

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -311,3 +311,7 @@ player:
   notgglemon:
     name: NotGGLemon
     reference: [https://x.com/NotGGLemon]
+  ajitama:
+    name: あじたま
+    alias: [Ajitama]
+    reference: [https://x.com/Ajitama_unite]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -330,6 +330,26 @@ eldivegaming:
       - https://eldivegaming.com/news/2023/0008.html
     date: 2023-06-09
   - member:
+      out:
+        - betchin
+        - gekkoan
+    reference:
+      - https://eldivegaming.com/news/2023/0011.html
+    date: 2023-08-15
+  - member:
+      out:
+        - wafu
+        - yupono
+    reference:
+      - https://eldivegaming.com/news/2023/0013.html
+    date: 2023-09-04
+  - member:
+      out:
+        - notgglemon
+    reference:
+      - https://eldivegaming.com/news/2023/0014.html
+    date: 2023-09-19
+  - member:
       in:
         - pixel
         - rati
@@ -337,6 +357,12 @@ eldivegaming:
     reference:
       - https://eldivegaming.com/news/2023/0016.html
     date: 2023-10-27
+  - member:
+      in:
+        - ajitama
+    reference:
+      - https://x.com/dive_el/status/1738122208466137286
+    date: 2023-12-22
   - member:
       out:
         - omutero


### PR DESCRIPTION
## Summary
- べちん選手・月光闇選手の脱退を追加
- Wafu選手・Yupono選手の脱退を追加
- NotGGLemon選手の脱退を追加
- あじたま選手の加入を追加

## Testing
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68b8357b732c8320b6c03e51a3fd4345