### PR TITLE
Add elDiveGaming roster update

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -287,6 +287,7 @@ player:
   pixel:
     name: Pixel
     alias: [ピクセル]
+    reference: [https://x.com/ES_PiXelPixel]
   rati:
     name: ラティ
     alias: []
@@ -296,6 +297,7 @@ player:
   maecha:
     name: まえちゃ
     alias: [Maecha]
+    reference: [https://x.com/xuzlv]
   betchin:
     name: Betchin
     alias: [べちん]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -381,3 +381,10 @@ eldivegaming:
     reference:
       - https://eldivegaming.com/news/2024/0010.html
     date: 2024-06-01
+  - member:
+      out:
+        - pixel
+        - maecha
+    reference:
+      - https://x.com/dive_el/status/1830168727628693802
+    date: 2024-09-01


### PR DESCRIPTION
## Summary
- record Pixel and Maecha leaving elDiveGaming on 2024-09-01
- add X references for Pixel and Maecha in member data

## Testing
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68b844bd34c883208495231f7e96900d