### PR TITLE
Add REALIZE Pokémon UNITE team and roster

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -130,7 +130,7 @@ player:
     reference: [https://x.com/Haruto_4_4]
   pavone:
     name: Pavóne
-    alias: [Pavone, Ireteya]
+    alias: [Pavone, Ireteya, いれてや]
     reference: [https://x.com/Pavone0223125]
   cotora:
     name: cotoRa
@@ -154,6 +154,10 @@ player:
     name: Kota
     alias: [コータ]
     reference: [https://x.com/RK_01130417]
+  nerie:
+    name: Nerie
+    alias: [ねりー]
+    reference: [https://x.com/tukaigeko]
   nomu:
     name: Nomu
     alias: [ノム]
@@ -317,3 +321,14 @@ player:
     name: あじたま
     alias: [Ajitama]
     reference: [https://x.com/Ajitama_unite]
+  sona:
+    name: Sona
+    alias: [そな]
+    reference: [https://x.com/sonapokeu]
+  ryunun:
+    name: Ryunun
+    alias: [りゅーぬん]
+    reference: [https://x.com/Ryunun0814]
+  mare:
+    name: mare
+    reference: [https://x.com/uniteniteu]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -388,3 +388,38 @@ eldivegaming:
     reference:
       - https://x.com/dive_el/status/1830168727628693802
     date: 2024-09-01
+realize:
+  - member:
+      in:
+        - wafu
+        - sona
+        - notgglemon
+        - ryunun
+        - mare
+    reference: [https://x.com/REALIZE_GO/status/1838141505015583096]
+    date: 2024-09-23
+  - member:
+      in:
+        - pavone
+    reference: [https://x.com/REALIZE_GO/status/1851187222952935526]
+    date: 2024-10-29
+  - member:
+      out:
+        - pavone
+    reference: [https://realize-esports.com/%e3%80%90-realize-%e3%83%9d%e3%82%b1%e3%83%a2%e3%83%b3%e3%83%a6%e3%83%8a%e3%82%a4%e3%83%88%e9%83%a8%e9%96%80-%e3%80%91/]
+    date: 2025-02-10
+  - member:
+      in:
+        - nerie
+    reference: [https://realize-esports.com/%e3%80%90-pokemon-unite%e9%83%a8%e9%96%80%e3%81%8a%e7%9f%a5%e3%82%89%e3%81%9b-%e3%80%91/]
+    date: 2025-04-10
+  - member:
+      out:
+        - wafu
+        - sona
+        - notgglemon
+        - ryunun
+        - mare
+        - nerie
+    reference: [https://x.com/REALIZE_GO/status/1917504207994904699]
+    date: 2025-04-30

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -74,3 +74,10 @@ eldivegaming:
     - エルダイブゲーミング
   reference:
     - https://eldivegaming.com/
+realize:
+  name: REALIZE
+  alias:
+    - リアライズ
+    - RLZ
+  reference:
+    - https://realize-esports.com/


### PR DESCRIPTION
## Summary
- add members Sona, Ryunun, mare, and Nerie
- register team REALIZE with official site
- document REALIZE roster: Sept 23 2024 launch lineup, Pavóne join Oct 29 2024, Pavóne exit Feb 10 2025, Nerie entry Apr 10 2025, final departures Apr 30 2025

## Testing
- `npm run validate`
- `curl -L -I https://realize-esports.com/`
- `curl -L -I https://realize-esports.com/%e3%80%90-realize-%e3%83%9d%e3%82%b1%e3%83%a2%e3%83%b3%e3%83%a6%e3%83%8a%e3%82%a4%e3%83%88%e9%83%a8%e9%96%80-%e3%80%91/`
- `curl -L -I https://x.com/REALIZE_GO/status/1917504207994904699`


------
https://chatgpt.com/codex/tasks/task_e_68b85ccfa7fc832090c684a176caeade