### PR TITLE
update E36 roster for Seno departure

### DIFF
--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -10,6 +10,12 @@ enterforce36:
     reference:
       - https://enterforce-36.com/2025/06/14/pokemon-unite-div/
     date: 2025-06-14
+  - member:
+      out:
+        - seno
+    reference:
+      - https://x.com/ENTERFORCE_36/status/1965611248370024589
+    date: 2025-09-10
 burning-core-toyama:
   - member:
       in:


### PR DESCRIPTION
## Summary
- record Seno leaving ENTER FORCE.36

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run validate`
- `npm run format`
- `npm run type-check` (fails: Property 'env' does not exist on type 'ImportMeta')

------
https://chatgpt.com/codex/tasks/task_e_68c1188b97248320bf6edd5e47c9e0c2