### PR TITLE
Update SCARZ roster departures

### DIFF
--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -161,6 +161,14 @@ scarz:
     reference:
       - https://www.scarz.net/news/25061902/
     date: 2025-06-19
+  - member:
+      out:
+        - cotora
+        - dorap1n
+    reference:
+      - https://x.com/SCARZ5/status/1972587154946588874
+      - https://scarz.net/news/25092901/
+    date: 2025-09-29
 yoshimoto-gaming:
   - member:
       in:


### PR DESCRIPTION
## Summary
- record the departures of cotoRa and Dorap1n from SCARZ's Pokémon UNITE division
- cite the official announcement and accompanying news post as references

## Testing
- npm run validate

------
https://chatgpt.com/codex/tasks/task_e_68dbdab9efb48320928a8761de42341a