### PR TITLE
Update FENNEL roster departures

### DIFF
--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -260,6 +260,13 @@ fennel:
     reference:
       - https://x.com/FENNEL_official/status/1929825395232169986
     date: 2025-06-03
+  - member:
+      out:
+        - serata
+        - yumenyan
+    reference:
+      - https://x.com/FENNEL_official/status/1972964649508520089
+    date: 2025-09-30
 nagoya-oja:
   - member:
       in:


### PR DESCRIPTION
## Summary
- add the September 30, 2025 departure announcement for Serata and yumenyan to FENNEL's roster history

## Testing
- npm run validate

------
https://chatgpt.com/codex/tasks/task_e_68dbdaffebfc832086aec52fa028c1b1