### PR TITLE
Add October 2025 FENNEL roster update

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -218,13 +218,17 @@ player:
   katastol:
     name: Katastol
     reference: [https://x.com/katastol_]
+  ak1:
+    name: ak1
+    alias: [亞樹]
+    reference: [https://x.com/sadako4709]
   lucapo:
     name: Lucapo
     alias: [ルカポー]
     reference: [https://x.com/po_o10xxx]
   mashio:
-    name: Ma・shio
-    alias: [ま・しお]
+    name: Ma・sh1o
+    alias: [ま・しお, Ma・shio]
     reference: [https://x.com/mashimashio3]
   pyi:
     name: pyi
@@ -239,6 +243,9 @@ player:
   serata:
     name: セラータ
     reference: [https://x.com/serata_0227]
+  setsunai:
+    name: setsunai
+    reference: [https://x.com/fortune_36]
   panchop:
     name: Panchop
     alias: [ぱんちょっぷ]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -305,6 +305,16 @@ fennel:
     reference:
       - https://x.com/FENNEL_official/status/1972964649508520089
     date: 2025-09-30
+  - member:
+      in:
+        - ak1
+        - b1
+        - mame
+        - setsunai
+    reference:
+      - https://x.com/FENNEL_official/status/1973342136763384224
+    date: 2025-10-01
+    memo: 発表ではMa・sh1oとpyiの継続も記載
 nagoya-oja:
   - member:
       in:


### PR DESCRIPTION
## Summary
- add ak1 and setsunai to the player master data along with the updated Ma・sh1o profile, including a kanji alias for ak1
- record the October 1, 2025 FENNEL roster announcement for new additions

## Testing
- npm run validate

------
https://chatgpt.com/codex/tasks/task_e_68dd0c6914008320bb8a6b753d11ffd0