### PR TITLE
Add tamerin to IGZIST roster

### DIFF
--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -906,6 +906,12 @@ igzist:
       - https://x.com/IGZIST_GG/status/2042558211262201963
     date: 2026-04-10
     memo: 羽舞クラリスはManager/Analystとして加入。
+  - member:
+      in:
+        - tamerin
+    reference:
+      - https://x.com/i/status/2061749669462450498
+    date: 2026-06-02
 area310:
   - member:
       in:


### PR DESCRIPTION
## Summary
Updates the IGZIST roster to include a new member joining on June 2, 2026.

## Changes
- Added tamerin as a new member to the IGZIST organization
- Recorded join date as 2026-06-02
- Added reference to the announcement tweet

## Details
This entry follows the existing roster format with member information and a reference link to the official announcement on X (Twitter).

https://claude.ai/code/session_015FgSPsFAjNiPmEd811p56v