### PR TITLE
feat: DOPENESSのPJCS2026メンバーを追加

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -570,3 +570,15 @@ player:
   mai:
     name: Mai
     reference: [https://x.com/mommomai]
+  dragon115:
+    name: ドラゴン115
+    reference: [https://x.com/ryu_kun1105]
+  kiryuuinhisui:
+    name: 鬼龍院ひスぃ
+    reference: [https://x.com/Re_Beatc]
+  ashigeshukii:
+    name: 芦毛しゅきぃ
+    reference: [https://x.com/mattyamonburann]
+  yoku:
+    name: Yoku
+    reference: [https://x.com/888_763]

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -977,6 +977,20 @@ dopeness:
     reference:
       - https://x.com/dopeness2021/status/2027941905615483024
     date: 2026-03-01
+  - member:
+      in:
+        - nonniini
+        - dragon115
+        - kiryuuinhisui
+        - ashigeshukii
+        - chokol
+        - yoku
+        - nyaito
+    reference:
+      - https://x.com/dopeness2021/status/2061749670469382393
+      - https://x.com/_VARREL/status/2061765563068928464
+    date: 2026-06-08
+    memo: PJCS2026参加メンバー。Nyaitoはコーチとして期限付きレンタル加入（VARRELより）。
 yotta:
   - member:
       in:

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -989,7 +989,7 @@ dopeness:
     reference:
       - https://x.com/dopeness2021/status/2061749670469382393
       - https://x.com/_VARREL/status/2061765563068928464
-    date: 2026-06-08
+    date: 2026-06-02
     memo: PJCS2026参加メンバー。Nyaitoはコーチとして期限付きレンタル加入（VARRELより）。
 yotta:
   - member:

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -987,6 +987,7 @@ dopeness:
         - yoku
         - nyaito
     reference:
+      - https://www.dopeness.jp/news/%E3%80%90pok%C3%A9mon-unite-div.%E3%80%91%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3%E3%82%B8%E3%83%A3%E3%83%91%E3%83%B3%E3%83%81%E3%83%A3%E3%83%B3%E3%83%94%E3%82%AA%E3%83%B3%E3%82%B7%E3%83%83%E3%83%97%E3%82%B92026%E5%87%BA%E5%A0%B4%E3%81%A8%E5%8A%A0%E5%85%A5%E3%81%AE%E3%81%8A%E7%9F%A5%E3%82%89%E3%81%9B
       - https://x.com/dopeness2021/status/2061749670469382393
       - https://x.com/_VARREL/status/2061765563068928464
     date: 2026-06-02


### PR DESCRIPTION
- member.yaml: ドラゴン115、鬼龍院ひスぃ、芦毛しゅきぃ、Yokuを新規追加
- roster.yaml: DOPENESS PJCS2026参加ロスターを追加
  - Nyaitoがコーチとしてオクロースルームより期限付きレンタル加入（VARRELより）

https://claude.ai/code/session_016qbvMYmxrMscW9evj3NeRh