### PR TITLE
NOZEL Pokémon UNITE Div.の新加入選手を追加

### DIFF
--- a/data/member.yaml
+++ b/data/member.yaml
@@ -582,3 +582,20 @@ player:
   yoku:
     name: Yoku
     reference: [https://x.com/888_763]
+  mazeran:
+    name: まぜらん
+    reference: [https://x.com/Magellannnnnnn]
+  obatoro:
+    name: おばとろ
+    reference: [https://x.com/omothisyeimi]
+  kasaparesu:
+    name: カサパレス
+    reference: [https://x.com/kasaparesu]
+  mirimu:
+    name: みりむ
+    alias: [merem]
+    reference: [https://x.com/xxmerxmxx]
+  rea:
+    name: れあ
+    reference: [https://x.com/l1sto2525]
+    memo: NOZEL Pokémon UNITE Div.のマネージャー

--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -1017,3 +1017,16 @@ yotta:
       - https://x.com/Yottatm/status/2016806022527275291
     date: 2026-01-29
     memo: 契約内容および体制の不備により部門解散
+nozel:
+  - member:
+      in:
+        - mazeran
+        - obatoro
+        - kasaparesu
+        - mirimu
+        - cinnamon
+        - rea
+    reference:
+      - https://x.com/NOZEL_gg/status/2082013296400719933
+    date: 2026-07-28
+    memo: れあはマネージャーとして加入。

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -146,3 +146,7 @@ dopeness:
   name: DOPENESS
   reference:
     - https://www.dopeness.jp/
+nozel:
+  name: NOZEL
+  reference:
+    - https://x.com/NOZEL_gg


### PR DESCRIPTION
まぜらん、おばとろ、カサパレス、みりむ、cinnamon、れあ(マネージャー)の加入を反映。NOZELチームを新規追加。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rf48yJoYkn1v4fiWq33NZp