### PR TITLE
DetonatioN FocusMe のポケモンユナイト部門終了をデータに反映

### DIFF
--- a/data/roster.yaml
+++ b/data/roster.yaml
@@ -955,6 +955,17 @@ detonation-focusme:
       - https://x.com/team_detonation/status/2040270774091780096
       - https://team-detonation.net/news/50959
     date: 2026-04-04
+  - member:
+      out:
+        - serata
+        - orenonaha
+        - ryunun
+        - kocoa
+        - karlow
+    reference:
+      - https://x.com/team_detonation/status/2089955686994075890
+    date: 2026-08-19
+    memo: ポケモンユナイト部門の競技活動終了に伴い脱退
 dopeness:
   - member:
       in:

--- a/data/team.yaml
+++ b/data/team.yaml
@@ -135,6 +135,8 @@ detonation-focusme:
     - DFM
   reference:
     - https://team-detonation.net/news/49637
+    - https://x.com/team_detonation/status/2089955686994075890
+  memo: 2026年8月19日にポケモンユナイトの競技活動終了を発表。
 yotta:
   name: YOTTA ESPORTS
   alias:


### PR DESCRIPTION
### Motivation
- DetonatioN FocusMe（DFM）が公式ツイートで「ポケモンユナイト部門 競技活動終了」を発表したため、リポジトリ内のチーム/ロスターデータへその旨を反映する。   

### Description
- `data/team.yaml` の `detonation-focusme` に公式発表（X / ツイート）への参照 URL と「競技活動終了」のメモを追加し、終了日を追記した。  
- `data/roster.yaml` の `detonation-focusme` に、競技活動終了の日付を記録するロスター更新（終了扱い）を追加した。  

### Testing
- 自動化テストは実行していません（データ追記のみの変更のため、手動で内容確認してください）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89278425a88320aa1380cd7eeaa4b4)